### PR TITLE
Restructure Claude commands with unified recodify namespace

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,1 +1,0 @@
-/home/sam/code/recodify-utils/devex/claude/commands/commit.md

--- a/.claude/commands/mkpr.md
+++ b/.claude/commands/mkpr.md
@@ -1,1 +1,0 @@
-/home/sam/code/recodify-utils/devex/claude/commands/mkpr.md

--- a/.claude/commands/recodify
+++ b/.claude/commands/recodify
@@ -1,0 +1,1 @@
+/home/sam/code/recodify-utils/devex/claude/commands

--- a/devex/claude/commands/fireaway.md
+++ b/devex/claude/commands/fireaway.md
@@ -1,0 +1,20 @@
+---
+name: fireaway
+description: |
+  calls a sequence of other custom claude commands
+example: |
+  /commit
+  git push origin [current branch]
+  /mkpr
+```
+---
+
+## Rules
+
+- DO NOT `git add`. Changes will have been staged already.
+- DO NOT offer to add if no changes staged, abort.
+- DO NOT push changes.
+- DO NOT add attribution.
+- DO NOT add co-author lines.
+- DO only create the commit message based on the stages changes.
+- DO NOT include details of changes that are not staged


### PR DESCRIPTION
Remove individual command symlinks and replace with single recodify directory symlink. Add fireaway command for automated workflow sequences.