### PR TITLE
Add portable Caps Lock disable script

### DIFF
--- a/devex/general/disable-capslock.sh
+++ b/devex/general/disable-capslock.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Disable or remap Caps Lock in a portable way.
+# Applies immediately to the current session (X11 or Wayland GNOME),
+# and persists where supported (Debian/Ubuntu keyboard-configuration, or localectl if present).
+#
+# Usage:
+#   ./capskill.sh                # disable Caps Lock
+#   ./capskill.sh --as-ctrl      # map Caps to Ctrl
+#   ./capskill.sh --layout us    # override layout (default gb)
+#   ./capskill.sh --model pc105  # override model
+#   ./capskill.sh --no-persist   # apply now, don't touch system defaults
+
+CAPS_OPT="caps:none"
+LAYOUT="gb"
+MODEL="pc105"
+PERSIST=true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --as-ctrl) CAPS_OPT="caps:ctrl_modifier"; shift ;;
+    --layout)  LAYOUT="${2:-$LAYOUT}"; shift 2 ;;
+    --model)   MODEL="${2:-$MODEL}"; shift 2 ;;
+    --no-persist) PERSIST=false; shift ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+have() { command -v "$1" >/dev/null 2>&1; }
+need_sudo() { if [[ $EUID -ne 0 ]]; then sudo "$@"; else "$@"; fi; }
+
+SESSION_TYPE="${XDG_SESSION_TYPE:-unknown}"
+IS_DEBIAN=false
+[[ -f /etc/debian_version ]] && IS_DEBIAN=true
+
+# --- Capability checks (no changes yet) ---
+CAN_APPLY_X11=false
+CAN_APPLY_WAYLAND=false
+
+if [[ "$SESSION_TYPE" == "x11" ]] && have setxkbmap; then
+  CAN_APPLY_X11=true
+fi
+
+# Only GNOME reliably honors gsettings xkb-options
+if [[ "$SESSION_TYPE" == "wayland" ]] && have gsettings; then
+  if gsettings list-schemas 2>/dev/null | grep -q '^org\.gnome\.desktop\.input-sources$'; then
+    CAN_APPLY_WAYLAND=true
+  fi
+fi
+
+if [[ "$CAN_APPLY_X11" == false && "$CAN_APPLY_WAYLAND" == false ]]; then
+  echo "❌ ERROR: Cannot apply in this session."
+  echo "   Session type: '$SESSION_TYPE'"
+  echo "   Needed tools:"
+  echo "     - X11: setxkbmap"
+  echo "     - Wayland GNOME: gsettings (org.gnome.desktop.input-sources), optionally ibus"
+  echo "   Aborting without making changes."
+  exit 1
+fi
+
+# --- Apply immediately to the running session ---
+apply_now_x11() {
+  # Clear any prior XKB options, then set desired caps behavior
+  setxkbmap -option || true
+  setxkbmap -option "$CAPS_OPT"
+}
+
+apply_now_wayland() {
+  gsettings set org.gnome.desktop.input-sources xkb-options "['$CAPS_OPT']"
+  if have ibus; then ibus restart || true; fi
+}
+
+echo "→ Session: $SESSION_TYPE"
+if [[ "$CAN_APPLY_X11" == true ]]; then
+  echo "→ Applying to current X11 session..."
+  apply_now_x11
+elif [[ "$CAN_APPLY_WAYLAND" == true ]]; then
+  echo "→ Applying to current Wayland (GNOME) session..."
+  apply_now_wayland
+fi
+
+# --- Persistence (optional and safe) ---
+if [[ "$PERSIST" == true ]]; then
+  # 1) Debian/Ubuntu persistence via /etc/default/keyboard
+  if [[ "$IS_DEBIAN" == true ]]; then
+    echo "→ Persisting via /etc/default/keyboard (Debian/Ubuntu)..."
+    need_sudo bash -c "cat >/etc/default/keyboard" <<EOF
+XKBMODEL="$MODEL"
+XKBLAYOUT="$LAYOUT"
+XKBVARIANT=""
+XKBOPTIONS="$CAPS_OPT"
+BACKSPACE="guess"
+EOF
+    # Apply to console and trigger input refresh
+    if have dpkg-reconfigure; then
+      need_sudo dpkg-reconfigure -f noninteractive keyboard-configuration || true
+    fi
+    if have udevadm; then
+      need_sudo udevadm trigger --subsystem-match=input --action=change || true
+    fi
+    if have setupcon; then
+      need_sudo setupcon || true
+    fi
+  fi
+
+  # 2) Generic: if localectl exists, set X11 defaults (optional; present on many distros)
+  if have localectl; then
+    echo "→ Persisting X11 defaults via localectl..."
+    need_sudo localectl set-x11-keymap "$LAYOUT" "$MODEL" "" "$CAPS_OPT" || true
+  fi
+else
+  echo "→ Skipping persistence (--no-persist)."
+fi
+
+# --- Verification ---
+echo "→ Verify current settings:"
+if [[ "$SESSION_TYPE" == "x11" && $CAN_APPLY_X11 == true ]]; then
+  setxkbmap -query || true
+elif [[ "$SESSION_TYPE" == "wayland" && $CAN_APPLY_WAYLAND == true ]]; then
+  gsettings get org.gnome.desktop.input-sources xkb-options 2>/dev/null || true
+fi
+if have localectl; then
+  echo
+  localectl status 2>/dev/null | sed -n '1,25p' || true
+fi
+
+echo "✅ Done. Caps behavior set to '$CAPS_OPT'."
+echo "   Layout: $LAYOUT  Model: $MODEL"
+echo "   Re-login may be required for DEs that cache input settings."


### PR DESCRIPTION
Add comprehensive script to disable or remap Caps Lock across different environments (X11/Wayland) with persistence support for Debian/Ubuntu systems.